### PR TITLE
fix: set correct type for MongoDB ObjectId in LotteryDraw model

### DIFF
--- a/loterias/models.py
+++ b/loterias/models.py
@@ -1,6 +1,9 @@
 from typing import Any, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
+from typing_extensions import Annotated
+
+PyObjectId = Annotated[str, BeforeValidator(str)]
 
 
 class ListaRateioPremioItem(BaseModel):
@@ -15,7 +18,7 @@ class ListaRateioPremioItem(BaseModel):
 class LotteryDraw(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
-    id: Any = Field(alias='_id', default=None)
+    id: Optional[PyObjectId] = Field(alias='_id', default=None)
     acumulado: bool
     data_apuracao: str = Field(..., alias='dataApuracao')
     data_proximo_concurso: str = Field(..., alias='dataProximoConcurso')


### PR DESCRIPTION
- Update `id` field in `LotteryDraw` model to use `PyObjectId` for proper MongoDB `ObjectId` handling

- Ensure accurate representation and compatibility with MongoDB database